### PR TITLE
Fix bugs 23 and 28, change references from olsen to olson.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Note that this function is used internally by ezTime, but does not by itself set
 
 Timezones in ezTime are objects. They can be created with `Timezone yourTZ`, where `yourTZ` is the name you choose to refer to the timezone. In this manual, this name will be used from now on. But you can naturally choose any name you want.
 
-Internally, ezTime stores everything it knows about a timezone as two strings. One is the official name of the timezone in "Olsen" format (like `Europe/Berlin`). That name is used to then update when needed all the other information needed to represent time in that timezone. This is in another string, in so-called "posix" format. It's often a little longer and for Berlin it is `CET-1CEST,M3.4.0/2,M10.4.0/3`. The elements of this string have the following meanings:
+Internally, ezTime stores everything it knows about a timezone as two strings. One is the official name of the timezone in "Olson" format (like `Europe/Berlin`). That name is used to then update when needed all the other information needed to represent time in that timezone. This is in another string, in so-called "posix" format. It's often a little longer and for Berlin it is `CET-1CEST,M3.4.0/2,M10.4.0/3`. The elements of this string have the following meanings:
 
 | Element | meaning |
 | ---- | ---- |
@@ -370,7 +370,7 @@ Provide the offset from UTC in minutes at the indicated time (or now if you do n
 
 `boolsetLocation(String location = "")`&nbsp;&nbsp;&nbsp;&nbsp;&mdash;&nbsp;**MUST** be prefixed with name of a timezone
 
-With `setLocation` you can provide a string to do an internet lookup for a timezone. The string can either be an Olsen timezone name, like `Europe/Berlin` (or some unique part of such a name). ([Here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) is a complete list of these names.) Or it can be a two-letter country code for any country that does not span multiple timezones, like `NL` or `DE` (but not `US`). After the information is retrieved, it is loaded in the current timezone, and cached if a cache is set (see below). `setLocation` will return `false` (Setting either `NO_NETWORK`, `DATA_NOT_FOUND` or `SERVER_ERROR`) if it cannot get timezone information.
+With `setLocation` you can provide a string to do an internet lookup for a timezone. The string can either be an Olson timezone name, like `Europe/Berlin` (or some unique part of such a name). ([Here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) is a complete list of these names.) Or it can be a two-letter country code for any country that does not span multiple timezones, like `NL` or `DE` (but not `US`). After the information is retrieved, it is loaded in the current timezone, and cached if a cache is set (see below). `setLocation` will return `false` (Setting either `NO_NETWORK`, `DATA_NOT_FOUND` or `SERVER_ERROR`) if it cannot get timezone information.
 
 If you provide no location ( `YourTZ.setLocation()` ), ezTime will attempt to do a GeoIP lookup to find the country associated with your IP-address. If that is a country that has a single timezone, that timezone will be loaded, otherwise a `SERVER_ERROR` ("Country Spans Multiple Timezones") will result.
 
@@ -410,7 +410,7 @@ To only get the timezone data from the internet when the cache is empty or outda
 
 `bool setCache(int16_t address)`&nbsp;&nbsp;&nbsp;&nbsp;&mdash;&nbsp;**MUST** be prefixed with name of a timezone
 
-If your ezTime is compiled with `#define EZTIME_CACHE_EEPROM` (which is the default), you can supply an EEPROM location. A single timezone needs 50 bytes to cache. The data is written in compressed form so that the Olsen and Posix strings fit in 3/4 of the space they would normally take up, and along with it is stored a checksum, a length field and a single byte for the month in which the cache was retrieved, in months after January 2018.
+If your ezTime is compiled with `#define EZTIME_CACHE_EEPROM` (which is the default), you can supply an EEPROM location. A single timezone needs 50 bytes to cache. The data is written in compressed form so that the Olson and Posix strings fit in 3/4 of the space they would normally take up, and along with it is stored a checksum, a length field and a single byte for the month in which the cache was retrieved, in months after January 2018.
 
 `bool setCache(String name, String key)`&nbsp;&nbsp;&nbsp;&nbsp;&mdash;&nbsp;**MUST** be prefixed with name of a timezone
 
@@ -473,7 +473,7 @@ We'll start with one of the most powerful functions of ezTime. With `dateTime` y
 | `s` | Seconds with leading zero
 | `T` | abbreviation for timezone, like `CEST`
 | `v` | milliseconds as three digits
-| `e` | Timezone identifier (Olsen name), like `Europe/Berlin`
+| `e` | Timezone identifier (Olson name), like `Europe/Berlin`
 | `O` | Difference to Greenwich time (GMT) in hours and minutes written together, like `+0200`. Here a positive offset means east of UTC.
 | `P` | Same as O but with a colon between hours and minutes, like `+02:00`
 | `Z` | Timezone offset in seconds. West of UTC is negative, east of UTC is positive.
@@ -1027,7 +1027,7 @@ ezTime 0.7.2 runs fine (No networking on board, so tested with NoNetwork example
 | [**`events`**](#events) | `void` | | no | no | no
 | [**`getOffset`**](#getoffset) | `int16_t` | `TIME` | optional | no | no
 | **function** | **returns** | **arguments** | **TZ prefix** | **network** | **cache** |
-| [**`getOlsen`**](#getolsen) | `String` | | optional | yes | yes |
+| [**`getOlson`**](#getolson) | `String` | | optional | yes | yes |
 | [**`getPosix`**](#getposix) | `String` | | yes | no | no
 | [**`getTimezoneName`**](#gettimezonename) | `String` | `TIME` | optional | no | no
 | [**`hour`**](#time-and-date-as-numbers) | `uint8_t` | `TIME` | optional | no | no

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Worse is when you set up a timezone for which you would like to retrieve the day
 
 ## Setting and synchronising time
 
-The NTP request from the scenario above failed because the network wasn't up yet, so the clock would still not be synchronised. A new request will be scheduled for 5 seconds later, and sent when your code (or `waitForSync`) calls `events`.
+The NTP request from the scenario above failed because the network wasn't up yet, so the clock would still not be synchronised. A new request will be scheduled for 1801 seconds later, and sent when your code (or `waitForSync`) calls `events`.
 
 &nbsp;
 
@@ -260,7 +260,7 @@ If your code uses timezones other than UTC, it might want to wait to initialise 
 
 `void setInterval(uint16_t seconds = 0);`
 
-By default, ezTime is set to poll `pool.ntp.org` every 10 minutes. These defaults should work for most people, but you can change them by specifying a new server with `setServer` or a new interval (in seconds) with setInterval. If you call setInterval with an interval of 0 seconds or call it as `setInterval()`, no more NTP queries will be made.
+By default, ezTime is set to poll `pool.ntp.org` about every 30 minutes. These defaults should work for most people, but you can change them by specifying a new server with `setServer` or a new interval (in seconds) with setInterval. If you call setInterval with an interval of 0 seconds or call it as `setInterval()`, no more NTP queries will be made.
 
 &nbsp;
 
@@ -268,7 +268,7 @@ By default, ezTime is set to poll `pool.ntp.org` every 10 minutes. These default
 
 `void updateNTP();`
 
-Updates the time from the NTP server immediately. Will keep retrying every 5 seconds (defined by `NTP_RETRY` in `ezTime.h`), will schedule the next update to happen after the normal interval.
+Updates the time from the NTP server immediately. Will keep retrying about every 30 minutes  (defined by `NTP_RETRY` in `ezTime.h`), will schedule the next update to happen after the normal interval.
 
 &nbsp;
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -53,7 +53,7 @@ militaryTZ	KEYWORD2
 setLocation	KEYWORD2
 setCache	KEYWORD2
 clearCache	KEYWORD2
-getOlsen	KEYWORD2
+getOlson	KEYWORD2
 
 # TimeLib compatibility
 

--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -741,8 +741,8 @@ time_t Timezone::tzTime(time_t t, ezLocalOrUTC_t local_or_utc, String &tzname, b
 	time_t dst_end = ezt::makeOrdinalTime(end_time_hr, end_time_min, 0, end_week, end_dow + 1, end_month, tm.Year + 1970);
 	
 	if (local_or_utc == UTC_TIME) {
-		dst_start -= std_offset;
-		dst_end -= dst_offset;
+		dst_start += std_offset * 60LL;
+		dst_end += dst_offset * 60LL;
 	}
 	
     if (dst_end > dst_start) {

--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -418,6 +418,9 @@ namespace ezt {
 				if (_ntp_interval) UTC.setEvent(updateNTP, t + _ntp_interval);
 				_time_status = timeSet;
 			} else {
+			        if ( nowUTC(false) > _last_sync_time + _ntp_interval + NTP_STALE_AFTER ) {
+			        	_time_status = timeNeedsSync;
+			        }
 				UTC.setEvent(updateNTP, nowUTC(false) + NTP_RETRY);
 			}
 		}

--- a/src/ezTime.h
+++ b/src/ezTime.h
@@ -136,9 +136,9 @@ typedef struct {
 #define NTP_LOCAL_PORT			4242
 #define NTP_SERVER				"pool.ntp.org"
 #define NTP_TIMEOUT				1500			// milliseconds
-#define NTP_INTERVAL			600				// default update interval in seconds
-#define NTP_RETRY				5				// Retry after this many seconds on failed NTP
-#define NTP_STALE_AFTER			3600			// If update due for this many seconds, set timeStatus to timeNeedsSync
+#define NTP_INTERVAL			1801				// default update interval in seconds
+#define NTP_RETRY			1801				// Retry after this many seconds on failed NTP
+#define NTP_STALE_AFTER			3602				// If update due for this many seconds, set timeStatus to timeNeedsSync
 
 #define TIMEZONED_REMOTE_HOST	"timezoned.rop.nl"
 #define TIMEZONED_REMOTE_PORT	2342

--- a/src/ezTime.h
+++ b/src/ezTime.h
@@ -237,13 +237,13 @@ class Timezone {
 		uint16_t year(time_t t = TIME_NOW, const ezLocalOrUTC_t local_or_utc = LOCAL_TIME);	
 		uint16_t yearISO(time_t t = TIME_NOW, const ezLocalOrUTC_t local_or_utc = LOCAL_TIME);
 	private:
-		String _posix, _olsen;
+		String _posix, _olson;
 		bool _locked_to_UTC;
  		
 	#ifdef EZTIME_NETWORK_ENABLE
 		public:
 			bool setLocation(const String location = "GeoIP");
-			String getOlsen();
+			String getOlson();
 		#ifdef EZTIME_CACHE_EEPROM
 			public:
 				bool setCache(const int16_t address);
@@ -262,7 +262,7 @@ class Timezone {
  			private:
  				bool setCache();
   				bool writeCache(String &str);
- 				bool readCache(String &olsen, String &posix, uint8_t &months_since_jan_2018);
+ 				bool readCache(String &olson, String &posix, uint8_t &months_since_jan_2018);
  				uint8_t _cache_month;
 		#endif
 	#endif	


### PR DESCRIPTION
Bug fixes have been tested locally. "Olsen" was a misspelling of "Olson" (changed s/lsen/lson in cpp, h, keywords and README files). Fixes described in bug discussions.

For Olson - may cause backward compat issues - it's a KEYWORD2.