### PR TITLE
Fixe for issue #38

### DIFF
--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -334,7 +334,7 @@ namespace ezt {
 		uint8_t m = month;   
 		uint8_t w = ordinal;
 		if (w == 5) ordinal = 0;
-		if (w == 0) {			// is this a "Last week" rule?
+		if (w == 5) {			// is this a "Last week" rule?
 			if (++m > 12) {		// yes, for "Last", go to the next month
 				m = 1;
 				++year;


### PR DESCRIPTION
The Function makeOrdinalTime does not work properly if you set the ordinal to 5 (Last dow in month and year) because you check if the value w is equal to 0 for the "Last week" rule. This will never happen. With the check if (w == 5) or  if (ordinal ==0) the code works perfectly.
This change fixes the issue #38