### PR TITLE
first internationalisation for German and Dutch

### DIFF
--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -151,36 +151,101 @@ namespace ezt {
 
 	////////////////////////
 
-	String monthStr(const uint8_t month) {
-		switch(month) {
-			case 1: return  F("January");
-			case 2: return  F("February");		
-			case 3: return  F("March");
-			case 4: return  F("April");
-			case 5: return  F("May");
-			case 6: return  F("June");
-			case 7: return  F("July");
-			case 8: return  F("August");
-			case 9: return  F("September");
-			case 10: return F("October");
-			case 11: return F("November");
-			case 12: return F("December");
+	#ifdef EZTIME_LANG_DE
+		String monthStr(const uint8_t month) {
+			switch(month) {
+				case 1: return  F("Januar");
+				case 2: return  F("Februar");		
+				case 3: return  F("März");
+				case 4: return  F("April");
+				case 5: return  F("Mai");
+				case 6: return  F("Juni");
+				case 7: return  F("Juli");
+				case 8: return  F("August");
+				case 9: return  F("September");
+				case 10: return F("Oktober");
+				case 11: return F("November");
+				case 12: return F("Dezember");
+			}
+			return "";
 		}
-		return "";
-	}
 
-	String dayStr(const uint8_t day) {
-		switch(day) {
-			case 1: return F("Sunday");
-			case 2: return F("Monday");
-			case 3: return F("Tuesday");		
-			case 4: return F("Wednesday");
-			case 5: return F("Thursday");
-			case 6: return F("Friday");
-			case 7: return F("Saturday");
+		String dayStr(const uint8_t day) {
+			switch(day) {
+				case 1: return F("Sonntag");
+				case 2: return F("Montag");
+				case 3: return F("Dienstag");		
+				case 4: return F("Mittwoch");
+				case 5: return F("Donnerstag");
+				case 6: return F("Freitag");
+				case 7: return F("Samstag");
+			}
+			return "";
 		}
-		return "";
-	}
+	#elif EZTIME_LANG_NL
+		String monthStr(const uint8_t month) {
+			switch(month) {
+				case 1: return  F("Januari");
+				case 2: return  F("Februari");		
+				case 3: return  F("Maart");
+				case 4: return  F("April");
+				case 5: return  F("Mei");
+				case 6: return  F("Juni");
+				case 7: return  F("Juli");
+				case 8: return  F("Augustus");
+				case 9: return  F("September");
+				case 10: return F("October");
+				case 11: return F("November");
+				case 12: return F("December");
+			}
+			return "";
+		}
+
+		String dayStr(const uint8_t day) {
+			switch(day) {
+				case 1: return F("Zondag");
+				case 2: return F("Maandag");
+				case 3: return F("Dinsdag");		
+				case 4: return F("Woensdag");
+				case 5: return F("Donderdag");
+				case 6: return F("Vrijdag");
+				case 7: return F("Zaterdag");
+			}
+			return "";
+		}
+	#else
+		String monthStr(const uint8_t month) {
+			switch(month) {
+				case 1: return  F("January");
+				case 2: return  F("February");		
+				case 3: return  F("March");
+				case 4: return  F("April");
+				case 5: return  F("May");
+				case 6: return  F("June");
+				case 7: return  F("July");
+				case 8: return  F("August");
+				case 9: return  F("September");
+				case 10: return F("October");
+				case 11: return F("November");
+				case 12: return F("December");
+			}
+			return "";
+		}
+
+		String dayStr(const uint8_t day) {
+			switch(day) {
+				case 1: return F("Sunday");
+				case 2: return F("Monday");
+				case 3: return F("Tuesday");		
+				case 4: return F("Wednesday");
+				case 5: return F("Thursday");
+				case 6: return F("Friday");
+				case 7: return F("Saturday");
+			}
+			return "";
+		}
+	#endif
+
 
 	// Original time lib compatibility
 	String dayShortStr(const uint8_t day) { return dayStr(day).substring(0,3); }
@@ -1241,9 +1306,15 @@ String Timezone::dateTime(time_t t, const ezLocalOrUTC_t local_or_utc, const Str
 				case 'd':	// Day of the month, 2 digits with leading zeros
 					out += ezt::zeropad(tm.Day, 2);
 					break;
-				case 'D':	// A textual representation of a day, three letters
-					out += ezt::dayStr(tm.Wday).substring(0,3);
-					break;
+				#ifdef EZTIME_TWO_LETTER_DAY
+					case 'D':	// A textual representation of a day, two letters
+						out += ezt::dayStr(tm.Wday).substring(0,2);
+						break;
+				#else
+					case 'D':	// A textual representation of a day, three letters
+						out += ezt::dayStr(tm.Wday).substring(0,3);
+						break;
+				#endif
 				case 'j':	// Day of the month without leading zeros
 					out += String(tm.Day);
 					break;


### PR DESCRIPTION
I wanted to add Dutch to ezTime, and noticed that @Nalsai did this for German in his own fork, but since i don't really want to keep my fork, i figured i could make a pull-request for it, and while i'm at it add German as well.

Would you like to include something like this in the library?

I made it so that by defining EZTIME_LANG_DE before import it gives German days and months
with EZTIME_LANG_NL it returns Dutch days and months
and when neither is defined it stays on the default English.

Also i added the define for EZTIME_TWO_LETTER_DAY since in NL we only use 2 letters to abbreviate the weekdays, so by defining this before importing the library 'D' gives only 2 letters.

If you'd like to import this, i can also look at documenting the feature..

thanks for a very nice library, i'm just starting to work with it, and i'm already liking it very much, it really is ez :-)