### PR TITLE
don't redefine language setting

### DIFF
--- a/src/ezTime.h
+++ b/src/ezTime.h
@@ -5,7 +5,9 @@
 #define _EZTIME_H_
 
 //Sets the language for the names of Months and Days. See the src/lang directory for supported languages
-#define EZTIME_LANGUAGE EN
+#ifndef EZTIME_LANGUAGE
+	#define EZTIME_LANGUAGE EN
+#endif
 
 // Compiles in NTP updating, timezoned fetching and caching 
 #define EZTIME_NETWORK_ENABLE


### PR DESCRIPTION
basic fix for #58 

in platformio.ini you can set the language like this

```
build_flags =
  -D EZTIME_LANGUAGE=NL
```