### PR TITLE
Fixes for #69 #70

### DIFF
--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -749,9 +749,7 @@ time_t Timezone::tzTime(time_t t, ezLocalOrUTC_t local_or_utc, String &tzname, b
 		if (tzname == "UTC" && std_offset) tzname = "???";
 		is_dst = false;
 		offset = std_offset;
-		return t - std_offset * 60;
-	}
-
+	} else {
 	int16_t dst_offset = std_offset - dst_shift_hr * 60 - dst_shift_min;
 	// to find the year
 	tmElements_t tm;
@@ -777,6 +775,7 @@ time_t Timezone::tzTime(time_t t, ezLocalOrUTC_t local_or_utc, String &tzname, b
 		tzname = _posix.substring(dstname_begin, dstname_end + 1);
 	} else {
 		offset = std_offset;
+	}
 	}
 
 	if (local_or_utc == LOCAL_TIME) {


### PR DESCRIPTION
I've made fixes to the two bugs I have found in ezTime: #69 #70.

I've tested these changes on a local device and seems to be working as expected now.

@ropg I know you were talking about a bigger re-write to ezTime eventually (to follow more conventional patterns where time_t should always be in UTC).  But hopefully this fixes a few small bugs until then.

Thanks for making this library open source! And letting me hopefully play a small roll in it.  It has seriously saved me a lot of time to not have to create this myself.