### PR TITLE
Add support for WifiEsp library

### DIFF
--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -20,6 +20,9 @@
 		#include <SPI.h>
 		#include <Ethernet.h>
 		#include <EthernetUdp.h>
+	#elif defined(EZTIME_WIFIESP)
+		#include <WifiEsp.h>
+		#include <WifiEspUdp.h>
 	#else
 		#include <WiFi.h>
 		#include <WiFiUdp.h>
@@ -416,7 +419,11 @@ namespace ezt {
 
 			#ifndef EZTIME_ETHERNET
 				if (WiFi.status() != WL_CONNECTED) { triggerError(NO_NETWORK); return false; }
-				WiFiUDP udp;
+				#ifndef EZTIME_WIFIESP
+					WiFiUDP udp;
+				#else
+					WiFiEspUDP udp;
+				#endif
 			#else
 				EthernetUDP udp;
 			#endif
@@ -799,7 +806,11 @@ String Timezone::getPosix() { return _posix; }
 		
 		#ifndef EZTIME_ETHERNET
 			if (WiFi.status() != WL_CONNECTED) { triggerError(NO_NETWORK); return false; }
-			WiFiUDP udp;
+			#ifndef EZTIME_WIFIESP
+				WiFiUDP udp;
+			#else
+				WiFiEspUDP udp;
+			#endif
 		#else
 			EthernetUDP udp;
 		#endif

--- a/src/ezTime.h
+++ b/src/ezTime.h
@@ -13,6 +13,9 @@
 // Arduino Ethernet shields
 // #define EZTIME_ETHERNET
 
+// Arduino board with ESP8266 shield
+// #define EZTIME_WIFIESP
+
 // Uncomment one of the below to only put only messages up to a certain level in the compiled code
 // (You still need to turn them on with setDebug(someLevel) to see them)
 // #define EZTIME_MAX_DEBUGLEVEL_NONE


### PR DESCRIPTION
This makes it possible to use ezTime with a standard Arduino board and ESP8266 WiFi shield, if `EZTIME_WIFIESP` is defined.

Thanks for creating such an easy-to-use library that "just works" for building an Arduino desk clock 🙂 