### PR TITLE
Added code to allow compilation for esp8266

### DIFF
--- a/examples/EventsAndOrdinalTime/EventsAndOrdinalTime.ino
+++ b/examples/EventsAndOrdinalTime/EventsAndOrdinalTime.ino
@@ -4,7 +4,11 @@
  */
 
 #include <ezTime.h>
+#ifdef ESP32
 #include <WiFi.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#endif
 
 void setup() {
 

--- a/examples/TimeFormats/TimeFormats.ino
+++ b/examples/TimeFormats/TimeFormats.ino
@@ -1,5 +1,9 @@
 #include <ezTime.h>
+#ifdef ESP32
 #include <WiFi.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#endif
 
 void setup() {
 

--- a/examples/Timezones/Timezones.ino
+++ b/examples/Timezones/Timezones.ino
@@ -1,5 +1,9 @@
 #include <ezTime.h>
+#ifdef ESP32
 #include <WiFi.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#endif
 
 void setup() {
 

--- a/examples/milliseconds/milliseconds.ino
+++ b/examples/milliseconds/milliseconds.ino
@@ -1,5 +1,9 @@
 #include <ezTime.h>
+#ifdef ESP32
 #include <WiFi.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#endif
 
 void setup() {
 


### PR DESCRIPTION
I got an error when trying to compile for esp8266 so I simply added 

```
#ifdef ESP32
#include <WiFi.h>
#elif defined(ESP8266)
#include <ESP8266WiFi.h>
#endif
```
The WiFi.h library is for esp32 so  I simply added some code to allow it to use ESP8266WiFi.h when the board being used is an esp8266 board.
